### PR TITLE
Added 3.18 to supported Shell versions

### DIFF
--- a/appmenu-regular-icons@example.com/metadata.json
+++ b/appmenu-regular-icons@example.com/metadata.json
@@ -2,7 +2,8 @@
   "description": "Sets The AppMenu Icon To Regular Mode. Disables Symbolic Icons.", 
   "name": "AppMenu Regular Icons", 
   "shell-version": [
-    "3.16"
+    "3.16",
+    "3.18"
   ],  
   "uuid": "appmenu-regular-icons@example.com", 
   "version": 1


### PR DESCRIPTION
Works without further ado in GNOME Shell 3.18.
The icons have got even smaller though.
