### PR TITLE
Add gnome 40.0 compatibility to metadata.json

### DIFF
--- a/appmenu-regular-icons@example.com/metadata.json
+++ b/appmenu-regular-icons@example.com/metadata.json
@@ -5,7 +5,8 @@
     "3.16",
     "3.18",
     "3.20",
-    "3.22"
+    "3.22",
+    "40.0"
   ],
   "settings-schema": "org.gnome.shell.extensions.appmenu-regular-icons",
   "uuid": "appmenu-regular-icons@example.com",


### PR DESCRIPTION
The extension is compatible with 40.0 without any modifications.